### PR TITLE
feat!: v3.0.0 - Major refactoring with new features and bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+*.egg-info/
+*.egg
+dist/
+build/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # Tarif EDF integration for Home Assistant
 
+Provides current electricity rates for French EDF contracts (Base, HP/HC, Tempo) with automatic tariff updates from official data.gouv.fr sources.
+
 ## Installation
 
 ### Using HACS
 
-[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=delphiki&repository=hass-tarif-edf&category=integration)
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=divers33&repository=hass-tarif-edf&category=integration)
 
 ### Manual install
 
@@ -14,36 +16,69 @@ Copy the `tarif_edf` folder from latest release to the `custom_components` folde
 
 [![Open your Home Assistant instance and add the integration via the UI.](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start/?domain=tarif_edf)
 
-## Available Sensors
+During setup, you'll be asked to:
+1. Select your contract type (Base, HP/HC, or Tempo)
+2. Select your subscribed power (kVA)
+3. For HP/HC contracts: enter your off-peak hours (e.g., `22:30-06:30` or `01:30-07:30,12:30-14:30`)
 
-### Common Sensors (All Contracts)
-| Sensor | Description | Unit | Example |
-|--------|-------------|------|---------|
-| `sensor.tarif_actuel_[type]_[power]kva_ttc` | Current applicable rate | EUR/kWh | `sensor.tarif_actuel_base_6kva_ttc` |
+## Available Entities
+
+### Common Entities (All Contracts)
+
+| Entity | Description | Unit |
+|--------|-------------|------|
+| `sensor.puissance_souscrite_[type]_[power]kva` | Subscribed power | kVA |
+| `sensor.tarif_actuel_[type]_[power]kva_ttc` | Current applicable rate | EUR/kWh |
 
 ### Base Contract
-| Sensor | Description | Unit |
+
+| Entity | Description | Unit |
 |--------|-------------|------|
 | `sensor.tarif_base_ttc` | Base rate | EUR/kWh |
+| `sensor.tarif_abonnement_base_ttc` | Monthly subscription | EUR/month |
 
 ### HP/HC Contract (Peak/Off-Peak)
-| Sensor | Description | Unit |
+
+**Important:** For HP/HC contracts, you must configure your off-peak hours during setup. Enter them as shown on your electricity bill using the format `HH:MM-HH:MM`. For multiple periods, separate with commas (e.g., `01:30-07:30,12:30-14:30`).
+
+| Entity | Description | Unit |
 |--------|-------------|------|
 | `sensor.tarif_heures_creuses_ttc` | Off-peak hours rate | EUR/kWh |
 | `sensor.tarif_heures_pleines_ttc` | Peak hours rate | EUR/kWh |
+| `sensor.tarif_abonnement_hphc_ttc` | Monthly subscription | EUR/month |
+| `binary_sensor.heures_creuses_hphc_[power]kva` | Off-peak hours indicator | on/off |
 
 ### Tempo Contract
-| Sensor | Description | Unit |
+
+| Entity | Description | Unit |
 |--------|-------------|------|
 | `sensor.tarif_tempo_couleur` | Current Tempo color | - |
 | `sensor.tarif_tempo_couleur_hier` | Yesterday's Tempo color | - |
-| `sensor.tarif_tempo_couleur_aujourd_hui` | Today's Tempo color | - |
+| `sensor.tarif_tempo_couleur_aujourdhui` | Today's Tempo color | - |
 | `sensor.tarif_tempo_couleur_demain` | Tomorrow's Tempo color | - |
-| `sensor.tarif_tempo_heures_creuses_ttc` | Current off-peak hours rate | EUR/kWh |
-| `sensor.tarif_tempo_heures_pleines_ttc` | Current peak hours rate | EUR/kWh |
+| `sensor.tarif_tempo_heures_creuses_ttc` | Current off-peak rate | EUR/kWh |
+| `sensor.tarif_tempo_heures_pleines_ttc` | Current peak rate | EUR/kWh |
 | `sensor.tarif_bleu_tempo_heures_creuses_ttc` | Blue days off-peak rate | EUR/kWh |
 | `sensor.tarif_bleu_tempo_heures_pleines_ttc` | Blue days peak rate | EUR/kWh |
 | `sensor.tarif_blanc_tempo_heures_creuses_ttc` | White days off-peak rate | EUR/kWh |
 | `sensor.tarif_blanc_tempo_heures_pleines_ttc` | White days peak rate | EUR/kWh |
 | `sensor.tarif_rouge_tempo_heures_creuses_ttc` | Red days off-peak rate | EUR/kWh |
 | `sensor.tarif_rouge_tempo_heures_pleines_ttc` | Red days peak rate | EUR/kWh |
+| `sensor.tarif_abonnement_tempo_ttc` | Monthly subscription | EUR/month |
+| `binary_sensor.heures_creuses_tempo_[power]kva` | Off-peak hours indicator | on/off |
+
+## Off-Peak Hours Binary Sensor
+
+The `binary_sensor.heures_creuses_*` entity is `on` when currently in off-peak hours, useful for automations:
+
+```yaml
+automation:
+  - alias: "Start dishwasher during off-peak"
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.heures_creuses_hphc_6kva
+        to: "on"
+    action:
+      - service: switch.turn_on
+        entity_id: switch.dishwasher
+```

--- a/custom_components/tarif_edf/__init__.py
+++ b/custom_components/tarif_edf/__init__.py
@@ -1,4 +1,5 @@
 """The Tarif EDF integration."""
+
 from __future__ import annotations
 
 from homeassistant.config_entries import ConfigEntry
@@ -9,11 +10,8 @@ from datetime import timedelta
 
 from .coordinator import TarifEdfDataUpdateCoordinator
 
-from .const import (
-    DOMAIN,
-    PLATFORMS,
-    DEFAULT_REFRESH_INTERVAL
-)
+from .const import DOMAIN, PLATFORMS, DEFAULT_REFRESH_INTERVAL
+
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Tarif EDF from a config entry."""
@@ -44,8 +42,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     return unload_ok
 
-async def update_listener(hass: HomeAssistant, entry: ConfigEntry):
-    """Handle options update."""
-    hass.data[DOMAIN][entry.entry_id]['coordinator'].update_interval = timedelta(days=entry.options.get("refresh_interval", DEFAULT_REFRESH_INTERVAL))
 
-    return True
+async def update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Handle options update."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+    refresh_interval = entry.options.get("refresh_interval", DEFAULT_REFRESH_INTERVAL)
+    coordinator.update_interval = timedelta(days=refresh_interval)

--- a/custom_components/tarif_edf/binary_sensor.py
+++ b/custom_components/tarif_edf/binary_sensor.py
@@ -4,10 +4,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
-from homeassistant.components.binary_sensor import (
-    BinarySensorEntity,
-    BinarySensorDeviceClass,
-)
+from homeassistant.components.binary_sensor import BinarySensorEntity
 
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -44,7 +41,7 @@ async def async_setup_entry(
 class TarifEdfOffPeakBinarySensor(CoordinatorEntity, BinarySensorEntity):
     """Binary sensor indicating if currently in off-peak hours."""
 
-    _attr_device_class = BinarySensorDeviceClass.POWER
+    _attr_device_class = None
 
     def __init__(self, coordinator: TarifEdfDataUpdateCoordinator) -> None:
         """Initialize the off-peak binary sensor."""

--- a/custom_components/tarif_edf/binary_sensor.py
+++ b/custom_components/tarif_edf/binary_sensor.py
@@ -1,0 +1,81 @@
+"""Binary sensor platform for the Tarif EDF integration."""
+
+from homeassistant.core import HomeAssistant
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
+from homeassistant.components.binary_sensor import (
+    BinarySensorEntity,
+    BinarySensorDeviceClass,
+)
+
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .coordinator import TarifEdfDataUpdateCoordinator
+
+from .const import (
+    DOMAIN,
+    CONTRACT_TYPE_HPHC,
+    CONTRACT_TYPE_TEMPO,
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Tarif EDF binary sensors from a config entry."""
+    coordinator: TarifEdfDataUpdateCoordinator = hass.data[DOMAIN][
+        config_entry.entry_id
+    ]["coordinator"]
+
+    contract_type = coordinator.data["contract_type"]
+
+    sensors = []
+
+    # Off-peak binary sensor (for HPHC and Tempo contracts)
+    if contract_type in [CONTRACT_TYPE_HPHC, CONTRACT_TYPE_TEMPO]:
+        sensors.append(TarifEdfOffPeakBinarySensor(coordinator))
+
+    async_add_entities(sensors, False)
+
+
+class TarifEdfOffPeakBinarySensor(CoordinatorEntity, BinarySensorEntity):
+    """Binary sensor indicating if currently in off-peak hours."""
+
+    _attr_device_class = BinarySensorDeviceClass.POWER
+
+    def __init__(self, coordinator: TarifEdfDataUpdateCoordinator) -> None:
+        """Initialize the off-peak binary sensor."""
+        super().__init__(coordinator)
+        contract_type = self.coordinator.data["contract_type"]
+        contract_power = self.coordinator.data["contract_power"]
+        contract_name = f"{contract_type.upper()} {contract_power}kVA"
+
+        self._attr_unique_id = f"tarif_edf_{contract_type}_{contract_power}_is_off_peak"
+        self._attr_name = f"Heures creuses {contract_type.upper()} {contract_power}kVA"
+        self._attr_device_info = DeviceInfo(
+            name=f"Tarif EDF - {contract_name}",
+            entry_type=DeviceEntryType.SERVICE,
+            identifiers={(DOMAIN, f"tarif_edf_{contract_type}_{contract_power}")},
+            manufacturer="Tarif EDF",
+            model=contract_name,
+        )
+
+    @property
+    def is_on(self) -> bool:
+        """Return True if currently in off-peak hours."""
+        return self.coordinator.data.get("is_off_peak", False)
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        """Return the state attributes."""
+        return {
+            "updated_at": self.coordinator.last_update_success_time,
+        }
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return self.coordinator.last_update_success

--- a/custom_components/tarif_edf/config_flow.py
+++ b/custom_components/tarif_edf/config_flow.py
@@ -1,4 +1,5 @@
 """Config flow for Tarif EDF integration."""
+
 from __future__ import annotations
 
 import logging
@@ -7,10 +8,9 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.data_entry_flow import FlowResult
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.core import callback
-from homeassistant.helpers.selector import SelectSelector
+from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers.selector import SelectSelector, SelectSelectorConfig
 
 from .const import (
     DOMAIN,
@@ -18,56 +18,130 @@ from .const import (
     CONTRACT_TYPE_BASE,
     CONTRACT_TYPE_HPHC,
     CONTRACT_TYPE_TEMPO,
-    TEMPO_OFFPEAK_HOURS
+    TEMPO_OFFPEAK_HOURS,
 )
 
 _LOGGER = logging.getLogger(__name__)
 
-STEP_USER = vol.Schema(
+# Power levels vary by contract type
+POWER_LEVELS_BASE = ["3", "6", "9", "12", "15"]
+POWER_LEVELS_HPHC_TEMPO = ["6", "9", "12", "15", "18", "30", "36"]
+
+POWER_LEVELS_BY_CONTRACT = {
+    CONTRACT_TYPE_BASE: POWER_LEVELS_BASE,
+    CONTRACT_TYPE_HPHC: POWER_LEVELS_HPHC_TEMPO,
+    CONTRACT_TYPE_TEMPO: POWER_LEVELS_HPHC_TEMPO,
+}
+
+STEP_CONTRACT_TYPE = vol.Schema(
     {
-        vol.Required("contract_power", default="6"): SelectSelector({
-            "options": ['3', '6', '9', '12', '15', '18', '30', '36'],
-            "mode": "dropdown"
-        }),
-        vol.Required("contract_type"): vol.In({
-            CONTRACT_TYPE_BASE: 'Base',
-            CONTRACT_TYPE_HPHC: 'Heures pleines / Heures creuses',
-            CONTRACT_TYPE_TEMPO: 'Tempo',
-        })
+        vol.Required("contract_type"): vol.In(
+            {
+                CONTRACT_TYPE_BASE: "Base",
+                CONTRACT_TYPE_HPHC: "Heures pleines / Heures creuses",
+                CONTRACT_TYPE_TEMPO: "Tempo",
+            }
+        )
     }
 )
 
-@config_entries.HANDLERS.register(DOMAIN)
+
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Tarif EDF."""
 
     VERSION = 1
 
-    async def async_step_user(self, user_input: dict | None = None) -> FlowResult:
-        """Handle a flow initialized by the user."""
-        _LOGGER.debug("Setup process initiated by user.")
+    def __init__(self) -> None:
+        """Initialize the config flow."""
+        self._contract_type: str | None = None
+        self._contract_power: str | None = None
 
+    async def async_step_user(self, user_input: dict | None = None) -> FlowResult:
+        """Handle the initial step triggered by the user."""
+        _LOGGER.debug("Setup process initiated by user.")
+        return await self.async_step_contract()
+
+    async def async_step_contract(self, user_input: dict | None = None) -> FlowResult:
+        """Handle the first step: contract type selection."""
         if user_input is None:
             return self.async_show_form(
-                step_id="user", data_schema=STEP_USER
+                step_id="contract", data_schema=STEP_CONTRACT_TYPE
             )
 
-        return self.async_create_entry(title="Option "+str.upper(user_input['contract_type']) + ", " + user_input['contract_power']+"kVA", data=user_input)
+        self._contract_type = user_input["contract_type"]
+        return await self.async_step_power()
+
+    async def async_step_power(self, user_input: dict | None = None) -> FlowResult:
+        """Handle the second step: power level selection."""
+        if user_input is None:
+            power_levels = POWER_LEVELS_BY_CONTRACT.get(
+                self._contract_type, POWER_LEVELS_HPHC_TEMPO
+            )
+            default_power = "6" if "6" in power_levels else power_levels[0]
+
+            schema = vol.Schema(
+                {
+                    vol.Required(
+                        "contract_power", default=default_power
+                    ): SelectSelector(
+                        SelectSelectorConfig(
+                            options=power_levels,
+                            mode="dropdown",
+                        )
+                    ),
+                }
+            )
+            return self.async_show_form(step_id="power", data_schema=schema)
+
+        self._contract_power = user_input["contract_power"]
+
+        # For HPHC, ask for off-peak hours
+        if self._contract_type == CONTRACT_TYPE_HPHC:
+            return await self.async_step_offpeak_hours()
+
+        # For BASE and TEMPO, create entry directly
+        return self._create_entry()
+
+    async def async_step_offpeak_hours(
+        self, user_input: dict | None = None
+    ) -> FlowResult:
+        """Handle the off-peak hours step for HPHC contracts."""
+        if user_input is None:
+            schema = vol.Schema(
+                {
+                    vol.Required("off_peak_hours_ranges"): str,
+                }
+            )
+            return self.async_show_form(step_id="offpeak_hours", data_schema=schema)
+
+        # Store off-peak hours in options
+        return self._create_entry(
+            options={"off_peak_hours_ranges": user_input["off_peak_hours_ranges"]}
+        )
+
+    def _create_entry(self, options: dict | None = None) -> FlowResult:
+        """Create the config entry."""
+        contract_type = self._contract_type
+        contract_power = self._contract_power
+        title = f"Option {contract_type.upper()}, {contract_power}kVA"
+
+        return self.async_create_entry(
+            title=title,
+            data={
+                "contract_type": contract_type,
+                "contract_power": contract_power,
+            },
+            options=options or {},
+        )
 
     @staticmethod
     @callback
     def async_get_options_flow(
         config_entry: config_entries.ConfigEntry,
-    ) -> config_entries.OptionsFlow:
+    ) -> OptionsFlowHandler:
         """Create the options flow."""
         return OptionsFlowHandler(config_entry.entry_id)
 
-class CannotConnect(HomeAssistantError):
-    """Error to indicate we cannot connect."""
-
-
-class InvalidAuth(HomeAssistantError):
-    """Error to indicate there is invalid auth."""
 
 class OptionsFlowHandler(config_entries.OptionsFlow):
     def __init__(self, config_entry_id: str) -> None:
@@ -84,15 +158,25 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         config_entry = self.hass.config_entries.async_get_entry(self.config_entry_id)
 
         default_offpeak_hours = None
-        if config_entry.data['contract_type'] == CONTRACT_TYPE_TEMPO:
+        if config_entry.data["contract_type"] == CONTRACT_TYPE_TEMPO:
             default_offpeak_hours = TEMPO_OFFPEAK_HOURS
 
         return self.async_show_form(
             step_id="init",
             data_schema=vol.Schema(
                 {
-                    vol.Optional("refresh_interval", default=config_entry.options.get("refresh_interval", DEFAULT_REFRESH_INTERVAL)): int,
-                    vol.Optional("off_peak_hours_ranges", default=config_entry.options.get("off_peak_hours_ranges", default_offpeak_hours)): str,
+                    vol.Optional(
+                        "refresh_interval",
+                        default=config_entry.options.get(
+                            "refresh_interval", DEFAULT_REFRESH_INTERVAL
+                        ),
+                    ): int,
+                    vol.Optional(
+                        "off_peak_hours_ranges",
+                        default=config_entry.options.get(
+                            "off_peak_hours_ranges", default_offpeak_hours
+                        ),
+                    ): str,
                 }
             ),
         )

--- a/custom_components/tarif_edf/const.py
+++ b/custom_components/tarif_edf/const.py
@@ -4,25 +4,26 @@ from homeassistant.const import Platform
 
 DOMAIN = "tarif_edf"
 
-CONTRACT_TYPE_BASE="base"
-CONTRACT_TYPE_HPHC="hphc"
-CONTRACT_TYPE_TEMPO="tempo"
+CONTRACT_TYPE_BASE = "base"
+CONTRACT_TYPE_HPHC = "hphc"
+CONTRACT_TYPE_TEMPO = "tempo"
 
-TARIF_BASE_URL="https://www.data.gouv.fr/fr/datasets/r/c13d05e5-9e55-4d03-bf7e-042a2ade7e49"
-TARIF_HPHC_URL="https://www.data.gouv.fr/fr/datasets/r/f7303b3a-93c7-4242-813d-84919034c416"
-TARIF_TEMPO_URL="https://www.data.gouv.fr/fr/datasets/r/0c3d1d36-c412-4620-8566-e5cbb4fa2b5a"
+TARIF_BASE_URL = (
+    "https://www.data.gouv.fr/fr/datasets/r/c13d05e5-9e55-4d03-bf7e-042a2ade7e49"
+)
+TARIF_HPHC_URL = (
+    "https://www.data.gouv.fr/fr/datasets/r/f7303b3a-93c7-4242-813d-84919034c416"
+)
+TARIF_TEMPO_URL = (
+    "https://www.data.gouv.fr/fr/datasets/r/0c3d1d36-c412-4620-8566-e5cbb4fa2b5a"
+)
 
-TEMPO_COLOR_API_URL="https://www.api-couleur-tempo.fr/api/jourTempo"
-TEMPO_COLORS_MAPPING={
-    0: "indéterminé",
-    1: "bleu",
-    2: "blanc",
-    3: "rouge"
-}
-TEMPO_DAY_START_AT="06:00"
-TEMPO_TOMRROW_AVAILABLE_AT="11:00"
-TEMPO_OFFPEAK_HOURS="22:00-06:00"
+TEMPO_COLOR_API_URL = "https://www.api-couleur-tempo.fr/api/jourTempo"
+TEMPO_COLORS_MAPPING = {0: "indéterminé", 1: "bleu", 2: "blanc", 3: "rouge"}
+TEMPO_DAY_START_AT = "06:00"
+TEMPO_TOMRROW_AVAILABLE_AT = "11:00"
+TEMPO_OFFPEAK_HOURS = "22:00-06:00"
 
-DEFAULT_REFRESH_INTERVAL=1
+DEFAULT_REFRESH_INTERVAL = 1
 
-PLATFORMS = [Platform.SENSOR]
+PLATFORMS = [Platform.SENSOR, Platform.BINARY_SENSOR]

--- a/custom_components/tarif_edf/coordinator.py
+++ b/custom_components/tarif_edf/coordinator.py
@@ -1,19 +1,23 @@
 """Data update coordinator for the Tarif EDF integration."""
+
 from __future__ import annotations
 
+import asyncio
+import csv
 from datetime import timedelta, datetime, date
-import time
+import logging
 import re
 from typing import Any
-import json
-import logging
-import requests
-import csv
+
+import aiohttp
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.update_coordinator import TimestampDataUpdateCoordinator
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.update_coordinator import (
+    TimestampDataUpdateCoordinator,
+    UpdateFailed,
+)
 
 from .const import (
     DEFAULT_REFRESH_INTERVAL,
@@ -27,42 +31,49 @@ from .const import (
     TEMPO_COLORS_MAPPING,
     TEMPO_DAY_START_AT,
     TEMPO_TOMRROW_AVAILABLE_AT,
-    TEMPO_OFFPEAK_HOURS
+    TEMPO_OFFPEAK_HOURS,
 )
 
 _LOGGER = logging.getLogger(__name__)
 
-def get_remote_file(url: str):
-    return requests.get(
-        url,
-        stream=True,
-        headers={
-            "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36"
-        },
-    )
+# HTTP request timeout in seconds
+HTTP_TIMEOUT = 30
 
-def str_to_time(str):
-    return datetime.strptime(str, '%H:%M').time()
+# User agent required by data.gouv.fr (returns 403 without it)
+USER_AGENT = "HomeAssistant-TarifEDF/3.0"
 
-def time_in_between(now, start, end):
+
+def str_to_time(time_str: str) -> datetime.time:
+    """Convert HH:MM string to time object."""
+    return datetime.strptime(time_str, "%H:%M").time()
+
+
+def str_to_date(date_str: str) -> date:
+    """Convert DD/MM/YYYY string to date object."""
+    return datetime.strptime(date_str, "%d/%m/%Y").date()
+
+
+def time_in_between(
+    now: datetime.time, start: datetime.time, end: datetime.time
+) -> bool:
+    """Check if current time is between start and end, handling midnight crossover."""
     if start <= end:
         return start <= now < end
     else:
         return start <= now or now < end
 
-def get_tempo_color_from_code(code):
-    return TEMPO_COLORS_MAPPING[code]
+
+def get_tempo_color_from_code(code: int) -> str:
+    """Get tempo color name from code."""
+    return TEMPO_COLORS_MAPPING.get(code, "indéterminé")
 
 
 class TarifEdfDataUpdateCoordinator(TimestampDataUpdateCoordinator):
     """Data update coordinator for the Tarif EDF integration."""
 
     config_entry: ConfigEntry
-    tempo_prices = []
 
-    def __init__(
-        self, hass: HomeAssistant, entry: ConfigEntry
-    ) -> None:
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
         """Initialize the coordinator."""
         super().__init__(
             hass=hass,
@@ -71,138 +82,339 @@ class TarifEdfDataUpdateCoordinator(TimestampDataUpdateCoordinator):
             update_interval=timedelta(minutes=1),
         )
         self.config_entry = entry
+        self.tempo_prices: list[dict] = []
+        self._session = async_get_clientsession(hass)
 
-    async def get_tempo_day(self, date):
-        date_str = date.strftime('%Y-%m-%d')
+    async def _async_fetch_url(self, url: str, as_json: bool = False) -> bytes | dict:
+        """Fetch URL content using the shared aiohttp session."""
+        headers = {"User-Agent": USER_AGENT}
+        async with asyncio.timeout(HTTP_TIMEOUT):
+            async with self._session.get(
+                url, headers=headers, allow_redirects=True
+            ) as response:
+                response.raise_for_status()
+                if as_json:
+                    return await response.json()
+                return await response.read()
+
+    async def get_tempo_day(self, target_date: date) -> dict:
+        """Fetch Tempo color for a specific date."""
+        date_str = target_date.strftime("%Y-%m-%d")
         now = datetime.now().time()
         check_limit = str_to_time(TEMPO_TOMRROW_AVAILABLE_AT)
 
+        # Check cache first
         for price in self.tempo_prices:
-            codeJour = price['codeJour']
-            if "dateJour" in price and price['dateJour'] == date_str and  \
-                (codeJour in [1,2,3] or (codeJour == 0 and now < check_limit)):
-                return price
+            code_jour = price.get("codeJour", 0)
+            if price.get("dateJour") == date_str:
+                # Return cached if color is known, or if unknown and before availability time
+                if code_jour in [1, 2, 3] or (code_jour == 0 and now < check_limit):
+                    return price
 
+        # Fetch from API
         url = f"{TEMPO_COLOR_API_URL}/{date_str}"
-        response = await self.hass.async_add_executor_job(get_remote_file, url)
-        response_json = response.json()
+        try:
+            response_json = await self._async_fetch_url(url, as_json=True)
 
-        self.tempo_prices.append(response_json)
+            # Validate response
+            if not isinstance(response_json, dict):
+                _LOGGER.warning(
+                    "Invalid Tempo API response for %s: not a dict", date_str
+                )
+                response_json = {"dateJour": date_str, "codeJour": 0}
+            elif "codeJour" not in response_json:
+                _LOGGER.warning(
+                    "Invalid Tempo API response for %s: missing codeJour", date_str
+                )
+                response_json = {"dateJour": date_str, "codeJour": 0}
 
-        return response_json
+            # Ensure dateJour is set
+            if "dateJour" not in response_json:
+                response_json["dateJour"] = date_str
 
-    async def _async_update_data(self) -> dict[Platform, dict[str, Any]]:
-        """Get the latest data from Tarif EDF and updates the state."""
-        data = self.config_entry.data
-        previous_data = None if self.data is None else self.data.copy()
+            # Cache the result
+            self.tempo_prices.append(response_json)
 
-        if previous_data is None:
-            self.data = {
-                "contract_power": data['contract_power'],
-                "contract_type": data['contract_type'],
-                "last_refresh_at": None,
-                "tarif_actuel_ttc": None
-            }
+            return response_json
 
-        fresh_data_limit = datetime.now() - timedelta(days=self.config_entry.options.get("refresh_interval", DEFAULT_REFRESH_INTERVAL))
+        except aiohttp.ClientError as err:
+            _LOGGER.warning("Error fetching Tempo color for %s: %s", date_str, err)
+            # Return a default response
+            return {"dateJour": date_str, "codeJour": 0}
+        except Exception as err:
+            _LOGGER.warning(
+                "Unexpected error fetching Tempo color for %s: %s", date_str, err
+            )
+            return {"dateJour": date_str, "codeJour": 0}
 
-        tarif_needs_update = self.data['last_refresh_at'] is None or self.data['last_refresh_at'] < fresh_data_limit
+    def _parse_tariff_csv(
+        self, content: bytes, contract_power: str, contract_type: str
+    ) -> dict | None:
+        """Parse tariff CSV and return the applicable rates based on current date."""
+        today = date.today()
+        decoded = content.decode("utf-8").splitlines()
+        reader = csv.DictReader(decoded, delimiter=";")
 
-        self.logger.info('EDF tarif_needs_update '+('yes' if tarif_needs_update else 'no'))
+        best_match = None
+        best_date = None
 
-        if tarif_needs_update:
-            if data['contract_type'] == CONTRACT_TYPE_BASE:
-                url = TARIF_BASE_URL
-            elif data['contract_type'] == CONTRACT_TYPE_HPHC:
-                    url = TARIF_HPHC_URL
-            elif data['contract_type'] == CONTRACT_TYPE_TEMPO:
-                    url = TARIF_TEMPO_URL
+        for row in reader:
+            try:
+                # Skip rows with empty date or wrong power
+                date_debut = row.get("DATE_DEBUT", "").strip()
+                # Try both column names: P_SOUSCRITE (TEMPO) and PUISSANCE (BASE/HPHC)
+                puissance = row.get("P_SOUSCRITE", row.get("PUISSANCE", "")).strip()
 
-            response = await self.hass.async_add_executor_job(get_remote_file, url)
-            parsed_content = csv.reader(response.content.decode('utf-8').splitlines(), delimiter=';')
-            rows = list(parsed_content)
-
-            for row in rows:
-                if row[1] == '' and row[2] == data['contract_power']:
-                    if data['contract_type'] == CONTRACT_TYPE_BASE:
-                        self.data['base_fixe_ttc'] = float(row[4].replace(",", "." ))
-                        self.data['base_variable_ttc'] = float(row[6].replace(",", "." ))
-                    elif data['contract_type'] == CONTRACT_TYPE_HPHC:
-                        self.data['hphc_fixe_ttc'] = float(row[4].replace(",", "." ))
-                        self.data['hphc_variable_hc_ttc'] = float(row[6].replace(",", "." ))
-                        self.data['hphc_variable_hp_ttc'] = float(row[8].replace(",", "." ))
-                    elif data['contract_type'] == CONTRACT_TYPE_TEMPO:
-                        self.data['tempo_fixe_ttc'] = float(row[4].replace(",", "." ))
-                        self.data['tempo_variable_hc_bleu_ttc'] = float(row[6].replace(",", "." ))
-                        self.data['tempo_variable_hp_bleu_ttc'] = float(row[8].replace(",", "." ))
-                        self.data['tempo_variable_hc_blanc_ttc'] = float(row[10].replace(",", "." ))
-                        self.data['tempo_variable_hp_blanc_ttc'] = float(row[12].replace(",", "." ))
-                        self.data['tempo_variable_hc_rouge_ttc'] = float(row[14].replace(",", "." ))
-                        self.data['tempo_variable_hp_rouge_ttc'] = float(row[16].replace(",", "." ))
-
-                    self.data['last_refresh_at'] = datetime.now()
-
-                    break
-            response.close
-
-        if data['contract_type'] == CONTRACT_TYPE_TEMPO:
-            today = date.today()
-            yesterday = today - timedelta(days=1)
-            tomorrow = today + timedelta(days=1)
-
-            tempo_yesterday = await self.get_tempo_day(yesterday)
-            tempo_today = await self.get_tempo_day(today)
-            tempo_tomorrow = await self.get_tempo_day(tomorrow)
-
-            yesterday_color = get_tempo_color_from_code(tempo_yesterday['codeJour'])
-            today_color = get_tempo_color_from_code(tempo_today['codeJour'])
-            tomorrow_color = get_tempo_color_from_code(tempo_tomorrow['codeJour'])
-
-            self.data['tempo_couleur_hier'] = yesterday_color
-            self.data['tempo_couleur_aujourdhui'] = today_color
-            self.data['tempo_couleur_demain'] = tomorrow_color
-
-            currentColorCode = tempo_yesterday['codeJour']
-
-            if datetime.now().time() >= str_to_time(TEMPO_DAY_START_AT):
-                self.logger.info("Using today's tempo prices")
-                currentColorCode = tempo_today['codeJour']
-            else:
-                self.logger.info("Using yesterday's tempo prices")
-
-            if currentColorCode in [1, 2, 3]:
-                color = get_tempo_color_from_code(currentColorCode)
-                self.data['tempo_couleur'] = color
-                self.data['tempo_variable_hp_ttc'] = self.data[f"tempo_variable_hp_{color}_ttc"]
-                self.data['tempo_variable_hc_ttc'] = self.data[f"tempo_variable_hc_{color}_ttc"]
-                self.data['last_refresh_at'] = datetime.now()
-
-        default_offpeak_hours = None
-        if data['contract_type'] == CONTRACT_TYPE_TEMPO:
-            default_offpeak_hours = TEMPO_OFFPEAK_HOURS
-        off_peak_hours_ranges = self.config_entry.options.get("off_peak_hours_ranges", default_offpeak_hours)
-
-        if data['contract_type'] == CONTRACT_TYPE_BASE:
-            self.data['tarif_actuel_ttc'] = self.data['base_variable_ttc']
-        elif data['contract_type'] in [CONTRACT_TYPE_HPHC, CONTRACT_TYPE_TEMPO] and off_peak_hours_ranges is not None:
-            contract_type_key = 'hphc' if data['contract_type'] == CONTRACT_TYPE_HPHC else 'tempo'
-            tarif_actuel = self.data[contract_type_key+'_variable_hp_ttc']
-            now = datetime.now().time()
-            for range in off_peak_hours_ranges.split(','):
-                if not re.match(r'([0-1]?[0-9]|2[0-3]):[0-5][0-9]-([0-1]?[0-9]|2[0-3]):[0-5][0-9]', range):
+                if not date_debut or puissance != contract_power:
                     continue
 
-                hours = range.split('-')
-                start_at = str_to_time(hours[0])
-                end_at = str_to_time(hours[1])
+                # Parse start date
+                start_date = str_to_date(date_debut)
 
-                if time_in_between(now, start_at, end_at):
-                    tarif_actuel = self.data[contract_type_key+'_variable_hc_ttc']
-                    break
+                # Skip if tariff not yet effective
+                if start_date > today:
+                    continue
 
-            self.data['tarif_actuel_ttc'] = tarif_actuel
+                # Parse end date if present
+                date_fin = row.get("DATE_FIN", "").strip()
+                if date_fin:
+                    end_date = str_to_date(date_fin)
+                    # Skip if tariff has expired
+                    if end_date < today:
+                        continue
 
-        self.logger.info('EDF Tarif')
-        self.logger.info(self.data)
+                # Select the most recent applicable tariff
+                if best_date is None or start_date > best_date:
+                    best_date = start_date
+                    best_match = row
+
+            except (ValueError, KeyError) as err:
+                _LOGGER.debug("Skipping row due to parse error: %s", err)
+                continue
+
+        if best_match is None:
+            return None
+
+        # Extract rates based on contract type
+        result = {}
+
+        def parse_price(value: str) -> float:
+            """Parse price string to float."""
+            if not value:
+                return 0.0
+            return float(value.replace(",", "."))
+
+        if contract_type == CONTRACT_TYPE_BASE:
+            result["base_fixe_ttc"] = parse_price(best_match.get("PART_FIXE_TTC", "0"))
+            result["base_variable_ttc"] = parse_price(
+                best_match.get("PART_VARIABLE_TTC", "0")
+            )
+            # Subscription is annual, divide by 12 for monthly
+            result["base_abonnement_ttc"] = result["base_fixe_ttc"] / 12
+
+        elif contract_type == CONTRACT_TYPE_HPHC:
+            result["hphc_fixe_ttc"] = parse_price(best_match.get("PART_FIXE_TTC", "0"))
+            result["hphc_variable_hc_ttc"] = parse_price(
+                best_match.get("PART_VARIABLE_HC_TTC", "0")
+            )
+            result["hphc_variable_hp_ttc"] = parse_price(
+                best_match.get("PART_VARIABLE_HP_TTC", "0")
+            )
+            # Subscription is annual, divide by 12 for monthly
+            result["hphc_abonnement_ttc"] = result["hphc_fixe_ttc"] / 12
+
+        elif contract_type == CONTRACT_TYPE_TEMPO:
+            result["tempo_fixe_ttc"] = parse_price(best_match.get("PART_FIXE_TTC", "0"))
+            result["tempo_variable_hc_bleu_ttc"] = parse_price(
+                best_match.get("PART_VARIABLE_HCBleu_TTC", "0")
+            )
+            result["tempo_variable_hp_bleu_ttc"] = parse_price(
+                best_match.get("PART_VARIABLE_HPBleu_TTC", "0")
+            )
+            result["tempo_variable_hc_blanc_ttc"] = parse_price(
+                best_match.get("PART_VARIABLE_HCBlanc_TTC", "0")
+            )
+            result["tempo_variable_hp_blanc_ttc"] = parse_price(
+                best_match.get("PART_VARIABLE_HPBlanc_TTC", "0")
+            )
+            result["tempo_variable_hc_rouge_ttc"] = parse_price(
+                best_match.get("PART_VARIABLE_HCRouge_TTC", "0")
+            )
+            result["tempo_variable_hp_rouge_ttc"] = parse_price(
+                best_match.get("PART_VARIABLE_HPRouge_TTC", "0")
+            )
+            # Subscription is annual, divide by 12 for monthly
+            result["tempo_abonnement_ttc"] = result["tempo_fixe_ttc"] / 12
+
+        return result
+
+    async def _async_update_data(self) -> dict[str, Any]:
+        """Get the latest data from Tarif EDF and updates the state."""
+        data = self.config_entry.data
+        contract_type = data["contract_type"]
+        contract_power = data["contract_power"]
+
+        if self.data is None:
+            self.data = {
+                "contract_power": contract_power,
+                "contract_type": contract_type,
+                "last_refresh_at": None,
+                "tarif_actuel_ttc": None,
+            }
+
+        refresh_interval = self.config_entry.options.get(
+            "refresh_interval", DEFAULT_REFRESH_INTERVAL
+        )
+        fresh_data_limit = datetime.now() - timedelta(days=refresh_interval)
+        tarif_needs_update = (
+            self.data.get("last_refresh_at") is None
+            or self.data["last_refresh_at"] < fresh_data_limit
+        )
+
+        _LOGGER.debug(
+            "EDF tarif_needs_update: %s", "yes" if tarif_needs_update else "no"
+        )
+
+        if tarif_needs_update:
+            # Select URL based on contract type
+            if contract_type == CONTRACT_TYPE_BASE:
+                url = TARIF_BASE_URL
+            elif contract_type == CONTRACT_TYPE_HPHC:
+                url = TARIF_HPHC_URL
+            elif contract_type == CONTRACT_TYPE_TEMPO:
+                url = TARIF_TEMPO_URL
+            else:
+                raise UpdateFailed(f"Unknown contract type: {contract_type}")
+
+            try:
+                content = await self._async_fetch_url(url)
+                rates = self._parse_tariff_csv(content, contract_power, contract_type)
+
+                if rates:
+                    self.data.update(rates)
+                    self.data["last_refresh_at"] = datetime.now()
+                else:
+                    _LOGGER.warning(
+                        "No matching tariff found for power %s kVA", contract_power
+                    )
+
+            except aiohttp.ClientError as err:
+                _LOGGER.error("Error fetching tariff data: %s", err)
+                raise UpdateFailed(f"Error fetching tariff data: {err}") from err
+            except Exception as err:
+                _LOGGER.error("Unexpected error fetching tariff data: %s", err)
+                raise UpdateFailed(f"Unexpected error: {err}") from err
+
+        # Handle Tempo-specific data
+        if contract_type == CONTRACT_TYPE_TEMPO:
+            today_date = date.today()
+            yesterday = today_date - timedelta(days=1)
+            tomorrow = today_date + timedelta(days=1)
+
+            try:
+                tempo_yesterday = await self.get_tempo_day(yesterday)
+                tempo_today = await self.get_tempo_day(today_date)
+                tempo_tomorrow = await self.get_tempo_day(tomorrow)
+
+                yesterday_color = get_tempo_color_from_code(
+                    tempo_yesterday.get("codeJour", 0)
+                )
+                today_color = get_tempo_color_from_code(tempo_today.get("codeJour", 0))
+                tomorrow_color = get_tempo_color_from_code(
+                    tempo_tomorrow.get("codeJour", 0)
+                )
+
+                self.data["tempo_couleur_hier"] = yesterday_color
+                self.data["tempo_couleur_aujourdhui"] = today_color
+                self.data["tempo_couleur_demain"] = tomorrow_color
+
+                # Determine current color based on time of day
+                # Before 06:00, use yesterday's color
+                current_color_code = tempo_yesterday.get("codeJour", 0)
+
+                if datetime.now().time() >= str_to_time(TEMPO_DAY_START_AT):
+                    _LOGGER.debug("Using today's tempo prices")
+                    current_color_code = tempo_today.get("codeJour", 0)
+                else:
+                    _LOGGER.debug("Using yesterday's tempo prices")
+
+                # Set current Tempo rates
+                if current_color_code in [1, 2, 3]:
+                    color = get_tempo_color_from_code(current_color_code)
+                    self.data["tempo_couleur"] = color
+
+                    hp_key = f"tempo_variable_hp_{color}_ttc"
+                    hc_key = f"tempo_variable_hc_{color}_ttc"
+
+                    if hp_key in self.data and hc_key in self.data:
+                        self.data["tempo_variable_hp_ttc"] = self.data[hp_key]
+                        self.data["tempo_variable_hc_ttc"] = self.data[hc_key]
+                else:
+                    # Color not yet determined
+                    self.data["tempo_couleur"] = "indéterminé"
+                    # Keep previous values if available, otherwise set to None
+                    if "tempo_variable_hp_ttc" not in self.data:
+                        self.data["tempo_variable_hp_ttc"] = None
+                    if "tempo_variable_hc_ttc" not in self.data:
+                        self.data["tempo_variable_hc_ttc"] = None
+
+            except Exception as err:
+                _LOGGER.error("Error fetching Tempo colors: %s", err)
+                # Set defaults to prevent KeyError
+                self.data.setdefault("tempo_couleur", "indéterminé")
+                self.data.setdefault("tempo_couleur_hier", "indéterminé")
+                self.data.setdefault("tempo_couleur_aujourdhui", "indéterminé")
+                self.data.setdefault("tempo_couleur_demain", "indéterminé")
+                self.data.setdefault("tempo_variable_hp_ttc", None)
+                self.data.setdefault("tempo_variable_hc_ttc", None)
+
+        # Calculate current tariff based on time of day
+        default_offpeak_hours = None
+        if contract_type == CONTRACT_TYPE_TEMPO:
+            default_offpeak_hours = TEMPO_OFFPEAK_HOURS
+        off_peak_hours_ranges = self.config_entry.options.get(
+            "off_peak_hours_ranges", default_offpeak_hours
+        )
+
+        if contract_type == CONTRACT_TYPE_BASE:
+            self.data["tarif_actuel_ttc"] = self.data.get("base_variable_ttc")
+            self.data["is_off_peak"] = False  # BASE has no off-peak
+
+        elif contract_type in [CONTRACT_TYPE_HPHC, CONTRACT_TYPE_TEMPO]:
+            contract_type_key = (
+                "hphc" if contract_type == CONTRACT_TYPE_HPHC else "tempo"
+            )
+            hp_key = f"{contract_type_key}_variable_hp_ttc"
+            hc_key = f"{contract_type_key}_variable_hc_ttc"
+
+            # Default to peak rate
+            tarif_actuel = self.data.get(hp_key)
+            is_off_peak = False
+
+            # Check if currently in off-peak hours
+            if off_peak_hours_ranges:
+                now = datetime.now().time()
+
+                for time_range in off_peak_hours_ranges.split(","):
+                    time_range = time_range.strip()
+                    if not re.match(
+                        r"([0-1]?[0-9]|2[0-3]):[0-5][0-9]-([0-1]?[0-9]|2[0-3]):[0-5][0-9]",
+                        time_range,
+                    ):
+                        continue
+
+                    hours = time_range.split("-")
+                    start_at = str_to_time(hours[0])
+                    end_at = str_to_time(hours[1])
+
+                    if time_in_between(now, start_at, end_at):
+                        tarif_actuel = self.data.get(hc_key)
+                        is_off_peak = True
+                        break
+
+            self.data["tarif_actuel_ttc"] = tarif_actuel
+            self.data["is_off_peak"] = is_off_peak
+
+        _LOGGER.debug("EDF Tarif data: %s", self.data)
 
         return self.data

--- a/custom_components/tarif_edf/manifest.json
+++ b/custom_components/tarif_edf/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/delphiki/hass-tarif-edf/issues",
   "requirements": [],
-  "version": "3.0.1"
+  "version": "3.1.0-beta.1"
 }

--- a/custom_components/tarif_edf/manifest.json
+++ b/custom_components/tarif_edf/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/delphiki/hass-tarif-edf/issues",
   "requirements": [],
-  "version": "3.0.0"
+  "version": "3.0.1"
 }

--- a/custom_components/tarif_edf/manifest.json
+++ b/custom_components/tarif_edf/manifest.json
@@ -8,5 +8,6 @@
   "documentation": "https://github.com/delphiki/hass-tarif-edf",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/delphiki/hass-tarif-edf/issues",
-  "version": "2.0.1"
+  "requirements": [],
+  "version": "3.0.0"
 }

--- a/custom_components/tarif_edf/sensor.py
+++ b/custom_components/tarif_edf/sensor.py
@@ -1,17 +1,15 @@
-from homeassistant.core import HomeAssistant
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
+"""Sensor platform for the Tarif EDF integration."""
+
 from homeassistant.components.sensor import (
     SensorEntity,
+    SensorStateClass,
 )
-
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-)
-
-
-from .coordinator import TarifEdfDataUpdateCoordinator
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
     DOMAIN,
@@ -19,93 +17,254 @@ from .const import (
     CONTRACT_TYPE_HPHC,
     CONTRACT_TYPE_TEMPO,
 )
+from .coordinator import TarifEdfDataUpdateCoordinator
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
-    async_add_entities: AddEntitiesCallback
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
+    """Set up Tarif EDF sensors from a config entry."""
     coordinator: TarifEdfDataUpdateCoordinator = hass.data[DOMAIN][
         config_entry.entry_id
     ]["coordinator"]
 
+    contract_type = coordinator.data["contract_type"]
+    contract_power = coordinator.data["contract_power"]
+
     sensors = [
-        TarifEdfSensor(coordinator, 'contract_power', f"Puissance souscrite {coordinator.data['contract_type']} {coordinator.data['contract_power']}kVA", 'kVA'),
+        TarifEdfSensor(
+            coordinator,
+            "contract_power",
+            f"Puissance souscrite {contract_type} {contract_power}kVA",
+            unit_of_measurement="kVA",
+            entity_category=EntityCategory.DIAGNOSTIC,
+        ),
     ]
 
-    if coordinator.data['contract_type'] == CONTRACT_TYPE_BASE:
-        sensors.extend([
-            TarifEdfSensor(coordinator, 'base_variable_ttc', 'Tarif Base TTC', 'EUR/kWh'),
-        ])
-    elif coordinator.data['contract_type'] == CONTRACT_TYPE_HPHC:
-        sensors.extend([
-            TarifEdfSensor(coordinator, 'hphc_variable_hc_ttc', 'Tarif Heures creuses TTC', 'EUR/kWh'),
-            TarifEdfSensor(coordinator, 'hphc_variable_hp_ttc', 'Tarif Heures pleines TTC', 'EUR/kWh'),
-        ])
-    elif coordinator.data['contract_type'] == CONTRACT_TYPE_TEMPO:
-        sensors.extend([
-            TarifEdfSensor(coordinator, 'tempo_couleur', 'Tarif Tempo Couleur'),
-            TarifEdfSensor(coordinator, 'tempo_couleur_hier', 'Tarif Tempo Couleur Hier'),
-            TarifEdfSensor(coordinator, 'tempo_couleur_aujourdhui', "Tarif Tempo Couleur Aujourd'hui"),
-            TarifEdfSensor(coordinator, 'tempo_couleur_demain', 'Tarif Tempo Couleur Demain'),
-            TarifEdfSensor(coordinator, 'tempo_variable_hc_ttc', 'Tarif Tempo Heures creuses TTC', 'EUR/kWh'),
-            TarifEdfSensor(coordinator, 'tempo_variable_hp_ttc', 'Tarif Tempo Heures pleines TTC', 'EUR/kWh'),
-            TarifEdfSensor(coordinator, 'tempo_variable_hc_bleu_ttc', 'Tarif Bleu Tempo Heures creuses TTC', 'EUR/kWh'),
-            TarifEdfSensor(coordinator, 'tempo_variable_hp_bleu_ttc', 'Tarif Bleu Tempo Heures pleines TTC', 'EUR/kWh'),
-            TarifEdfSensor(coordinator, 'tempo_variable_hc_rouge_ttc', 'Tarif Rouge Tempo Heures creuses TTC', 'EUR/kWh'),
-            TarifEdfSensor(coordinator, 'tempo_variable_hp_rouge_ttc', 'Tarif Rouge Tempo Heures pleines TTC', 'EUR/kWh'),
-            TarifEdfSensor(coordinator, 'tempo_variable_hc_blanc_ttc', 'Tarif Blanc Tempo Heures creuses TTC', 'EUR/kWh'),
-            TarifEdfSensor(coordinator, 'tempo_variable_hp_blanc_ttc', 'Tarif Blanc Tempo Heures pleines TTC', 'EUR/kWh'),
-        ])
+    if contract_type == CONTRACT_TYPE_BASE:
+        sensors.extend(
+            [
+                TarifEdfSensor(
+                    coordinator,
+                    "base_variable_ttc",
+                    "Tarif Base TTC",
+                    "EUR/kWh",
+                    state_class=SensorStateClass.MEASUREMENT,
+                ),
+                TarifEdfSensor(
+                    coordinator,
+                    "base_abonnement_ttc",
+                    "Tarif Abonnement Base TTC",
+                    "EUR/mois",
+                    state_class=SensorStateClass.MEASUREMENT,
+                ),
+            ]
+        )
 
-    if coordinator.data['tarif_actuel_ttc'] is not None:
+    elif contract_type == CONTRACT_TYPE_HPHC:
+        sensors.extend(
+            [
+                TarifEdfSensor(
+                    coordinator,
+                    "hphc_variable_hc_ttc",
+                    "Tarif Heures creuses TTC",
+                    "EUR/kWh",
+                    state_class=SensorStateClass.MEASUREMENT,
+                ),
+                TarifEdfSensor(
+                    coordinator,
+                    "hphc_variable_hp_ttc",
+                    "Tarif Heures pleines TTC",
+                    "EUR/kWh",
+                    state_class=SensorStateClass.MEASUREMENT,
+                ),
+                TarifEdfSensor(
+                    coordinator,
+                    "hphc_abonnement_ttc",
+                    "Tarif Abonnement HPHC TTC",
+                    "EUR/mois",
+                    state_class=SensorStateClass.MEASUREMENT,
+                ),
+            ]
+        )
+
+    elif contract_type == CONTRACT_TYPE_TEMPO:
+        sensors.extend(
+            [
+                # Current and daily color sensors (no state_class for text values)
+                TarifEdfSensor(
+                    coordinator,
+                    "tempo_couleur",
+                    "Tarif Tempo Couleur",
+                    state_class=None,
+                ),
+                TarifEdfSensor(
+                    coordinator,
+                    "tempo_couleur_hier",
+                    "Tarif Tempo Couleur Hier",
+                    state_class=None,
+                ),
+                TarifEdfSensor(
+                    coordinator,
+                    "tempo_couleur_aujourdhui",
+                    "Tarif Tempo Couleur Aujourd'hui",
+                    state_class=None,
+                ),
+                TarifEdfSensor(
+                    coordinator,
+                    "tempo_couleur_demain",
+                    "Tarif Tempo Couleur Demain",
+                    state_class=None,
+                ),
+                # Current rates
+                TarifEdfSensor(
+                    coordinator,
+                    "tempo_variable_hc_ttc",
+                    "Tarif Tempo Heures creuses TTC",
+                    "EUR/kWh",
+                    state_class=SensorStateClass.MEASUREMENT,
+                ),
+                TarifEdfSensor(
+                    coordinator,
+                    "tempo_variable_hp_ttc",
+                    "Tarif Tempo Heures pleines TTC",
+                    "EUR/kWh",
+                    state_class=SensorStateClass.MEASUREMENT,
+                ),
+                # Blue day rates
+                TarifEdfSensor(
+                    coordinator,
+                    "tempo_variable_hc_bleu_ttc",
+                    "Tarif Bleu Tempo Heures creuses TTC",
+                    "EUR/kWh",
+                    state_class=SensorStateClass.MEASUREMENT,
+                ),
+                TarifEdfSensor(
+                    coordinator,
+                    "tempo_variable_hp_bleu_ttc",
+                    "Tarif Bleu Tempo Heures pleines TTC",
+                    "EUR/kWh",
+                    state_class=SensorStateClass.MEASUREMENT,
+                ),
+                # White day rates
+                TarifEdfSensor(
+                    coordinator,
+                    "tempo_variable_hc_blanc_ttc",
+                    "Tarif Blanc Tempo Heures creuses TTC",
+                    "EUR/kWh",
+                    state_class=SensorStateClass.MEASUREMENT,
+                ),
+                TarifEdfSensor(
+                    coordinator,
+                    "tempo_variable_hp_blanc_ttc",
+                    "Tarif Blanc Tempo Heures pleines TTC",
+                    "EUR/kWh",
+                    state_class=SensorStateClass.MEASUREMENT,
+                ),
+                # Red day rates
+                TarifEdfSensor(
+                    coordinator,
+                    "tempo_variable_hc_rouge_ttc",
+                    "Tarif Rouge Tempo Heures creuses TTC",
+                    "EUR/kWh",
+                    state_class=SensorStateClass.MEASUREMENT,
+                ),
+                TarifEdfSensor(
+                    coordinator,
+                    "tempo_variable_hp_rouge_ttc",
+                    "Tarif Rouge Tempo Heures pleines TTC",
+                    "EUR/kWh",
+                    state_class=SensorStateClass.MEASUREMENT,
+                ),
+                # Subscription
+                TarifEdfSensor(
+                    coordinator,
+                    "tempo_abonnement_ttc",
+                    "Tarif Abonnement Tempo TTC",
+                    "EUR/mois",
+                    state_class=SensorStateClass.MEASUREMENT,
+                ),
+            ]
+        )
+
+    # Current tariff sensor
+    if coordinator.data.get("tarif_actuel_ttc") is not None:
         sensors.append(
-            TarifEdfSensor(coordinator, 'tarif_actuel_ttc', f"Tarif actuel {coordinator.data['contract_type']} {coordinator.data['contract_power']}kVA TTC", 'EUR/kWh')
+            TarifEdfSensor(
+                coordinator,
+                "tarif_actuel_ttc",
+                f"Tarif actuel {contract_type} {contract_power}kVA TTC",
+                "EUR/kWh",
+                state_class=SensorStateClass.MEASUREMENT,
+            )
         )
 
     async_add_entities(sensors, False)
 
+
 class TarifEdfSensor(CoordinatorEntity, SensorEntity):
     """Representation of a Tarif EDF sensor."""
 
-    def __init__(self, coordinator, coordinator_key: str, name: str, unit_of_measurement: str = None) -> None:
+    def __init__(
+        self,
+        coordinator: TarifEdfDataUpdateCoordinator,
+        coordinator_key: str,
+        name: str,
+        unit_of_measurement: str | None = None,
+        state_class: SensorStateClass | None = None,
+        entity_category: EntityCategory | None = None,
+    ) -> None:
         """Initialize the Tarif EDF sensor."""
         super().__init__(coordinator)
-        contract_name = str.upper(self.coordinator.data['contract_type']) + " " + self.coordinator.data['contract_power'] + "kVA"
+        contract_type = self.coordinator.data["contract_type"]
+        contract_power = self.coordinator.data["contract_power"]
+        contract_name = f"{contract_type.upper()} {contract_power}kVA"
 
         self._coordinator_key = coordinator_key
-        self._name = name
-        self._attr_unique_id = f"tarif_edf_{self._name}"
+
+        # Use coordinator_key for unique_id to ensure uniqueness
+        self._attr_unique_id = (
+            f"tarif_edf_{contract_type}_{contract_power}_{coordinator_key}"
+        )
         self._attr_name = name
         self._attr_device_info = DeviceInfo(
             name=f"Tarif EDF - {contract_name}",
             entry_type=DeviceEntryType.SERVICE,
-            identifiers={
-                (DOMAIN, f"Tarif EDF - {contract_name}")
-            },
+            identifiers={(DOMAIN, f"tarif_edf_{contract_type}_{contract_power}")},
             manufacturer="Tarif EDF",
             model=contract_name,
         )
-        if (unit_of_measurement is not None):
-            self._attr_unit_of_measurement = unit_of_measurement
+
+        if unit_of_measurement is not None:
+            self._attr_native_unit_of_measurement = unit_of_measurement
+
+        if state_class is not None:
+            self._attr_state_class = state_class
+
+        if entity_category is not None:
+            self._attr_entity_category = entity_category
 
     @property
     def native_value(self):
         """Return the state of the sensor."""
-        if self.coordinator.data[self._coordinator_key] is None:
-            return 'unavailable'
-        else:
-            return self.coordinator.data[self._coordinator_key]
+        value = self.coordinator.data.get(self._coordinator_key)
+        if value is None:
+            return None
+        return value
 
     @property
-    def extra_state_attributes(self):
+    def extra_state_attributes(self) -> dict:
         """Return the state attributes."""
         return {
-            'updated_at': self.coordinator.last_update_success_time,
-            'unit_of_measurement': self._attr_unit_of_measurement,
+            "updated_at": self.coordinator.last_update_success_time,
         }
 
     @property
     def available(self) -> bool:
         """Return if entity is available."""
-        return self.coordinator.last_update_success and self.coordinator.data[self._coordinator_key] is not None
+        return (
+            self.coordinator.last_update_success
+            and self.coordinator.data.get(self._coordinator_key) is not None
+        )

--- a/custom_components/tarif_edf/strings.json
+++ b/custom_components/tarif_edf/strings.json
@@ -1,10 +1,21 @@
 {
   "config": {
     "step": {
-      "user": {
+      "contract": {
         "data": {
-          "contract_power": "Puissance (kVA)",
-          "contract_type": "Contrat"
+          "contract_type": "Contract type"
+        }
+      },
+      "power": {
+        "data": {
+          "contract_power": "Power (kVA)"
+        }
+      },
+      "offpeak_hours": {
+        "title": "Off-peak hours",
+        "description": "Enter your off-peak hours as shown on your electricity bill. Use format HH:MM-HH:MM. For multiple periods, separate with commas.\n\nExamples:\n- 22:30-06:30 (single period overnight)\n- 01:30-07:30,12:30-14:30 (two periods)",
+        "data": {
+          "off_peak_hours_ranges": "Off-peak hours"
         }
       }
     },
@@ -23,7 +34,7 @@
         "description": "Customize the way the integration works",
         "data": {
           "refresh_interval": "Data refresh interval (in days)",
-          "off_peaks_hours_ranges": "Off peak hours ranges (HH:MM-HH:MM,HH:MM-HH:MM,...)"
+          "off_peak_hours_ranges": "Off peak hours ranges (HH:MM-HH:MM,HH:MM-HH:MM,...)"
         }
       }
     }

--- a/custom_components/tarif_edf/translations/en.json
+++ b/custom_components/tarif_edf/translations/en.json
@@ -9,10 +9,21 @@
             "unknown": "Unexpected error"
         },
         "step": {
-            "user": {
+            "contract": {
                 "data": {
-                    "contract_type": "Option",
-                    "power": "Power (kVA)"
+                    "contract_type": "Contract type"
+                }
+            },
+            "power": {
+                "data": {
+                    "contract_power": "Power (kVA)"
+                }
+            },
+            "offpeak_hours": {
+                "title": "Off-peak hours",
+                "description": "Enter your off-peak hours as shown on your electricity bill. Use format HH:MM-HH:MM. For multiple periods, separate with commas.\n\nExamples:\n- 22:30-06:30 (single period overnight)\n- 01:30-07:30,12:30-14:30 (two periods)",
+                "data": {
+                    "off_peak_hours_ranges": "Off-peak hours"
                 }
             }
         }

--- a/custom_components/tarif_edf/translations/fr.json
+++ b/custom_components/tarif_edf/translations/fr.json
@@ -9,10 +9,21 @@
             "unknown": "Erreur inattendue"
         },
         "step": {
-            "user": {
+            "contract": {
                 "data": {
-                    "contract_type": "Option",
+                    "contract_type": "Type de contrat"
+                }
+            },
+            "power": {
+                "data": {
                     "contract_power": "Puissance (kVA)"
+                }
+            },
+            "offpeak_hours": {
+                "title": "Heures creuses",
+                "description": "Saisissez vos heures creuses telles qu'indiquées sur votre facture d'électricité. Utilisez le format HH:MM-HH:MM. Pour plusieurs plages, séparez par des virgules.\n\nExemples :\n- 22:30-06:30 (une plage de nuit)\n- 01:30-07:30,12:30-14:30 (deux plages)",
+                "data": {
+                    "off_peak_hours_ranges": "Heures creuses"
                 }
             }
         }


### PR DESCRIPTION
## Summary

This PR brings significant improvements to the Tarif EDF integration, including new features, bug fixes, and alignment with Home Assistant best practices.

### ✨ New Features

- **Off-peak hours binary sensor**: New `binary_sensor.heures_creuses_[type]_[power]kva` entity indicates when in off-peak hours (HP/HC and Tempo contracts)
- **Multi-step configuration**: New setup wizard guides users through contract type, power, and off-peak hours selection
- **Off-peak hours configuration for HP/HC**: HP/HC contracts now prompt for off-peak hours during setup (format: `HH:MM-HH:MM`)
- **Subscription sensors**: Monthly subscription cost sensors for all contract types
- **Multiple contracts support**: Unique IDs now include contract type and power, allowing multiple contracts simultaneously
- **Power level filtering**: Power levels filtered by contract type during setup

### 🐛 Bug Fixes

- Fixed `KeyError` on `tempo_variable_hp_ttc` when Tempo color is unavailable (#47)
- Fixed CSV parsing to use correct column name `P_SOUSCRITE` for TEMPO contracts
- Restored User-Agent header required by data.gouv.fr APIs (was returning 403 errors)
- Improved error handling for API failures with graceful fallbacks

### 🔧 Code Quality & HA Best Practices

- Use shared aiohttp session (`async_get_clientsession`) instead of creating new sessions
- Removed deprecated `@config_entries.HANDLERS.register` decorator
- Added `EntityCategory.DIAGNOSTIC` to contract_power sensor
- Modern type annotations (`str | None` instead of `Optional`)
- Removed unnecessary dependencies from manifest.json
- Added comprehensive README documentation
- All ruff checks pass
- HACS validation passes

### Test plan

- [x] Ruff linter passes
- [x] Ruff formatter passes
- [x] hassfest validation passes
- [x] HACS Action validation passes
- [x] Manual testing with BASE contract
- [x] Manual testing with HP/HC contract
- [x] Manual testing with TEMPO contract